### PR TITLE
specify licensing for models

### DIFF
--- a/create_model.py
+++ b/create_model.py
@@ -9,11 +9,24 @@ from cellpose import models
 model_names = [
     "cyto",
     "nuclei",
-    # "tissuenet",
-    # "livecell",
     "cyto2",
     "CP",
     "CPx",
+
+    # "tissuenet",
+    # "livecell",
+    "TN1",
+    "TN2",
+    "TN3",
+    "LC1",
+    "LC2",
+    "LC3",
+    "LC4",
+]
+
+model_names_CCBYNC = [
+    # "tissuenet",
+    # "livecell",
     "TN1",
     "TN2",
     "TN3",
@@ -105,7 +118,10 @@ for model in model_names:
         documentation=doc_file,
         # additional metadata about authors, licenses, citation etc.
         authors=[{"name": "Carsen Stringer", "affiliation": "Janelia"}],
-        license="CC-BY-4.0",
+        if model in model_names_CCBYNC:
+            license="CC-BY-NC-4.0",
+        else:
+            license="CC-BY-4.0",
         tags=["cellpose-segmentation"],  # the tags are used to make models more findable on the website
         cite=[{"text": "Stringer et al.", "doi": "doi:10.1038/s41592-020-01018-x"}],
     )


### PR DESCRIPTION
Hi,

with Cellpose 3.0, the licensing gets more complicated. They specifically say: :triangular_flag_on_post: All models in Cellpose, except `yeast_BF_cp3`, `yeast_PhC_cp3`, and `deepbacs_cp3`, are trained on some amount of data that is **CC-BY-NC**. The Cellpose annotated dataset is also CC-BY-NC. 

While reusing CC-BY-NC data in a new dataset, it usually means publishing the dataset under CC-BY-NC. I am afraid here it would be the same.

**But because of the specific model names, are we gaming at models from Cellpose 2.0? If that is the case, I specified the licensing for the models based on the documentation and information provided.**

Hope it helps!
Martin

